### PR TITLE
Add [qa skip] directive, similar to [ci skip] standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ rake fourchette:enable   # This enables Fourchette hook
 rake fourchette:update   # This updates the Fourchette hook with the current URL of the app
 ```
 
+## QA Skip
+
+Adding `[qa skip]` to the title of your pull request will cause Fourchette to ignore the pull request. This is inspired by the `[ci skip]` directive that [various](http://docs.travis-ci.com/user/how-to-skip-a-build/) [ci tools](https://circleci.com/docs/skip-a-build) support.
+
 ## Async processing note
 
 Fourchette uses [Sucker Punch](https://github.com/brandonhilkert/sucker_punch), "a single-process Ruby asynchronous processing library". No need for redis or extra processes. It also mean it can run for free on Heroku, if this is what you want.

--- a/lib/fourchette/pull_request.rb
+++ b/lib/fourchette/pull_request.rb
@@ -2,6 +2,8 @@ class Fourchette::PullRequest
   include SuckerPunch::Job
 
   def perform params
+    return if qa_skip?(params)
+
     callbacks = Fourchette::Callbacks.new(params)
     fork = Fourchette::Fork.new(params)
 
@@ -20,4 +22,11 @@ class Fourchette::PullRequest
 
     callbacks.after_all
   end
+
+  private
+
+  def qa_skip? params
+    params['pull_request']['title'].downcase.include?('[qa skip]')
+  end
+
 end

--- a/spec/lib/fourchette/pull_request_spec.rb
+++ b/spec/lib/fourchette/pull_request_spec.rb
@@ -11,27 +11,33 @@ describe Fourchette::PullRequest do
     end
 
     context 'action == synchronize' do
-      let!(:params) { { 'action' => 'synchronize' } }
+      let!(:params) { { 'action' => 'synchronize', 'pull_request' => { 'title' => 'Test Me' } } }
 
       it { fork.should_receive(:update) }
     end
 
     context 'action == closed' do
-      let!(:params) { { 'action' => 'closed' } }
+      let!(:params) { { 'action' => 'closed', 'pull_request' => { 'title' => 'Test Me' } } }
 
       it { fork.should_receive(:delete) }
     end
 
     context 'action == reopened' do
-      let!(:params) { { 'action' => 'reopened' } }
+      let!(:params) { { 'action' => 'reopened', 'pull_request' => { 'title' => 'Test Me' } } }
 
       it { fork.should_receive(:create) }
     end
 
     context 'action == opened' do
-      let!(:params) { { 'action' => 'opened' } }
+      let!(:params) { { 'action' => 'opened', 'pull_request' => { 'title' => 'Test Me' } } }
 
       it { fork.should_receive(:create) }
+    end
+
+    context 'title includes [qa skip]' do
+      let!(:params) { { 'action' => 'opened', 'pull_request' => { 'title' => 'Skip Me [QA Skip]' } } }
+
+      it { fork.should_not_receive(:create) }
     end
   end
 end


### PR DESCRIPTION
Similar to the [ci skip] standard (https://circleci.com/docs/skip-a-build) this skips out on forking a new app for simple PRs that do not require it.
