### PR TITLE
Giving support to new PG Heroku addon name

### DIFF
--- a/lib/fourchette/heroku.rb
+++ b/lib/fourchette/heroku.rb
@@ -96,7 +96,7 @@ class Fourchette::Heroku
 
   def pg_enabled?(app)
     client.addon.list(app).any? do |addon|
-      addon['addon_service']['name'] == 'Heroku Postgres'
+      addon['addon_service']['name'] =~ /heroku.postgres/i
     end
   end
 end

--- a/spec/lib/fourchette/heroku_spec.rb
+++ b/spec/lib/fourchette/heroku_spec.rb
@@ -133,15 +133,27 @@ describe Fourchette::Heroku do
     end
 
     context 'when a heroku-postgresql addon is enabled' do
-      let(:addon_list) do
-        [{ 'addon_service' => { 'name' => 'Heroku Postgres' } }]
+      let(:addon_list) { [{ 'addon_service' => { 'name' => addon_name } }] }
+
+      shared_examples 'app with pg' do
+        it 'calls Fourchette::Pgbackups#copy' do
+          expect_any_instance_of(Fourchette::Pgbackups).to receive(:copy).with(
+            from_app_name, to_app_name
+          )
+          heroku.copy_pg(from_app_name, to_app_name)
+        end
       end
 
-      it 'calls Fourchette::Pgbackups#copy' do
-        expect_any_instance_of(Fourchette::Pgbackups).to receive(:copy).with(
-          from_app_name, to_app_name
-        )
-        heroku.copy_pg(from_app_name, to_app_name)
+      context "when the addon name is 'Heroku Postgres'" do
+        let(:addon_name) { 'Heroku Postgres' }
+
+        it_behaves_like 'app with pg'
+      end
+
+      context "when the addon name is 'heroku-postgresql'" do
+        let(:addon_name) { 'heroku-postgresql' }
+
+        it_behaves_like 'app with pg'
       end
     end
 


### PR DESCRIPTION
I don't know If we're the only ones with this issue, but a couple days ago our Fourchette clones on Heroku began to fail on our apps because the app is beig created, yes, but without PG data.

The issue happens during the clon creation process:
![captura de pantalla 2015-03-04 a las 10 45 15](https://cloud.githubusercontent.com/assets/1227578/6483028/b0305956-c26c-11e4-8ea6-f1e41845ddf6.png)

**Postgres not enabled on rankia. Skipping data copy.**

The thing is that Postgres actually was enabled (on our two apps), and we could navigate through them and their seed data.

Then I started investigating why Fourchette thinks that Postgres is not enabled, so I locally cloned fourchette and tried with a `rake console`.
I asked the app to show what name get's for the PG addon:
![captura de pantalla 2015-03-04 a las 10 50 23](https://cloud.githubusercontent.com/assets/1227578/6483081/27042dd2-c26d-11e4-8c04-7de31dc1758d.png)

And then the result was:
![captura de pantalla 2015-03-04 a las 10 53 08](https://cloud.githubusercontent.com/assets/1227578/6483095/5265f4a6-c26d-11e4-92e9-d3a7e200264e.png)

`pg_enabled?` is checking for and exact match of 'Heroku Postgres', but when we ask the addon is named as "heroku-postgresql". It doesn't match, says that pg is not enabled and... no pg copy is done.

As I don't know if this is a generalized issue, I tried to maintain backwards compatibility so both names will work (and some possible variants too).

After that we checked it again agains our Heroku app and...
![captura de pantalla 2015-03-04 a las 12 36 39](https://cloud.githubusercontent.com/assets/1227578/6483177/4b6efe12-c26e-11e4-876b-ef8d7da9a7da.png)





