### PR TITLE
fix missing parameter. Test cover of Pgbackups class

### DIFF
--- a/lib/fourchette/pgbackups.rb
+++ b/lib/fourchette/pgbackups.rb
@@ -20,16 +20,16 @@ class Fourchette::Pgbackups
   private
 
   def ensure_pgbackups_is_present(heroku_app_name)
-    unless existing_backups?
+    unless existing_backups?(heroku_app_name)
       logger.info "Adding pgbackups to #{heroku_app_name}"
       @heroku.client.addon.create(heroku_app_name, { plan: 'pgbackups' })
     end
   end
 
-  def existing_backups?
-    @heroku.client.addon.list(heroku_app_name).select do |addon|
+  def existing_backups?(heroku_app_name)
+    @heroku.client.addon.list(heroku_app_name).any? do |addon|
       addon['name'] == 'pgbackups'
-    end.any?
+    end
   end
 
   def pg_details_for(app_name)

--- a/spec/lib/fourchette/pgbackups_spec.rb
+++ b/spec/lib/fourchette/pgbackups_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe Fourchette::Pgbackups do
+  describe '#copy' do
+    let(:from_app_name) { 'awesome app' }
+    let(:to_app_name) { 'awesomer app!' }
+    let(:pg_backup) { Fourchette::Pgbackups.new }
+    let(:heroku) { instance_double(Fourchette::Heroku) }
+
+    let(:config_vars_from) do
+      { 'HEROKU_POSTGRESQL_FROM_URL' => 'postgres://from...',
+        'PGBACKUPS_URL' => 'postgres://frombackup...' }
+    end
+
+    let(:config_vars_to) do
+      { 'HEROKU_POSTGRESQL_TO_URL' => 'postgres://to...',
+        'PGBACKUPS_URL' => 'postgres://tobackup...' }
+    end
+
+    before do
+      allow(Fourchette::Heroku).to receive(:new).and_return(heroku)
+
+      allow(heroku)
+        .to receive_message_chain(:client, :addon, :list)
+        .and_return([{ 'name' => addon_name }])
+
+      allow(heroku)
+        .to receive(:config_vars)
+        .with(from_app_name)
+        .and_return(config_vars_from)
+
+      allow(heroku)
+        .to receive(:config_vars)
+        .with(to_app_name)
+        .and_return(config_vars_to)
+    end
+
+    context 'when Pgbackups addon is enabled' do
+      let(:addon_name) { 'pgbackups' }
+      let(:backup) { instance_double(Heroku::Client::Pgbackups) }
+
+      it 'launches a PG backup from origin app to destination one' do
+        expect(Heroku::Client::Pgbackups)
+          .to receive(:new)
+          .with(config_vars_from['PGBACKUPS_URL'] + '/api')
+          .and_return(backup)
+
+        expect(backup).to receive(:create_transfer).with(
+          config_vars_from['HEROKU_POSTGRESQL_FROM_URL'],
+          'HEROKU_POSTGRESQL_FROM_URL',
+          config_vars_to['HEROKU_POSTGRESQL_TO_URL'],
+          'HEROKU_POSTGRESQL_TO_URL'
+        )
+
+        pg_backup.copy(from_app_name, to_app_name)
+      end
+    end
+
+    context 'when Pgbackups addon is not enabled' do
+      let(:addon_name) { 'addon' }
+
+      it 'enables Pgbackups addon and launches a PG backup' do
+        expect(heroku)
+          .to receive_message_chain(:client, :addon, :create)
+          .with(to_app_name, { plan: 'pgbackups' })
+
+        expect(heroku)
+          .to receive_message_chain(:client, :addon, :create)
+          .with(from_app_name, { plan: 'pgbackups' })
+
+        expect(Heroku::Client::Pgbackups)
+          .to receive_message_chain(:new, :create_transfer)
+
+        pg_backup.copy(from_app_name, to_app_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here I am again. 
After applying changes done at https://github.com/rainforestapp/fourchette/pull/54, we tried again and found a new problem.

![captura de pantalla 2015-03-04 a las 13 50 44](https://cloud.githubusercontent.com/assets/1227578/6489634/27c9534a-c2a0-11e4-9c02-e51218920309.png)

Seems that during a method extraction refactor (https://github.com/rainforestapp/fourchette/commit/f27c08432914da6688abc8711422d0d5e57e92d1) the typical "oh, I forget to pass the parameter to the new extracted method" (happens too many times to me U_U') was introduced.

So the new method is calling `heroku_app_name`, variable that is not defined in his scope.

I tried to avoid future errors through a basic test covering of the class.  I'm **not**  proud of tests that I created here, since I had to stub A LOT just to be able to test what calls we want to be done.

Also it was very difficult for me trying to isolate expectations to one per test, because if I isolate expectations I would have to create new stubs for the different internal calls at each test. So, tired of trying too complicated things, I decided to move to a "well, it works" approach. Better than nothing.
